### PR TITLE
RNMT-2634 Set self-heal mechanism as a preference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [Unreleased]
+
+- Self healing mechanism
+
 ## cordova-sqlcipher-adapter 0.1.7
 
 - Fix Windows build

--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ The self-heal mechanism consists in deleting the previous encrypted local databa
 
 By default, this mechanism is disabled, but if you wish to use it you should use the following syntax in `config.xml`:
 ```
-  <preference name="selfHealing" value="true" />
+  <preference name="EnableSQLCipherSelfHealing" value="true" />
 ```
 
 # Database schema versions

--- a/README.md
+++ b/README.md
@@ -648,6 +648,17 @@ with `location` or `iosDatabaseLocation` parameter *required* as described above
 
 **BUG:** When a database is deleted, any queued transactions for that database are left hanging. All pending transactions should be errored when a database is deleted.
 
+## Self Healing Mechanism
+
+The self-healing mechanism is a mechanism that helps to recover mobile apps that are unable to open the ciphered local database. One known scenario when this can happen is when the mobile app's endpoint changes between versions.
+
+The self-heal mechanism consists in deleting the previous encrypted local database and to create a new one. So, instead of clients having errors in their apps, they will only lose the local configurations of the apps and no error screen will be shown. 
+
+By default, this mechanism is disabled, but if you wish to use it you should use the following syntax in `config.xml`:
+```
+  <preference name="selfHealing" value="true" />
+```
+
 # Database schema versions
 
 The transactional nature of the API makes it relatively straightforward to manage a database schema that may be upgraded over time (adding new columns or new tables, for example). Here is the recommended procedure to follow upon app startup:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-sqlcipher-adapter",
-  "version": "0.1.7-os.3",
+  "version": "0.1.7-OS3",
   "description": "SQLCipher database adapter for PhoneGap/Cordova, based on cordova-sqlite-storage",
   "cordova": {
     "id": "cordova-sqlcipher-adapter",

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,6 +26,8 @@
         <clobbers target="SQLitePlugin" />
     </js-module>
 
+    <dependency id="com.outsystems.plugins.logger" />
+
     <!-- android -->
     <platform name="android">
         <!-- Cordova >= 3.0.0 -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-sqlcipher-adapter"
-    version="0.1.7-os.3">
+    version="0.1.7-OS3">
 
     <name>Cordova sqlcipher adapter</name>
 

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -73,7 +73,7 @@ public class SQLitePlugin extends CordovaPlugin {
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
         logger = OSLogger.getInstance();
-        selfHealingEnabled = preferences.getBoolean("selfHealing", false);
+        selfHealingEnabled = preferences.getBoolean("EnableSQLCipherSelfHealing", false);
         SQLiteAndroidDatabase.initialize(cordova);
     }
 

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -266,7 +266,7 @@ public class SQLitePlugin extends CordovaPlugin {
             // NOTE: NO Android locking/closing BUG workaround needed here
 
             if(selfHealingEnabled && e.getMessage().contains("file is encrypted or is not a database:")) {
-                logger.logError("Android database will be deleted to self heal:" + e.getMessage(), "SQLite");
+                logger.logError("Android database will be deleted to self heal: " + e.getMessage(), "SQLite");
                 deleteDatabaseNow(dbname);
                 return openDatabase(dbname, key, cbc, false);
             } else {

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -266,7 +266,7 @@ public class SQLitePlugin extends CordovaPlugin {
             // NOTE: NO Android locking/closing BUG workaround needed here
 
             if(selfHealingEnabled && e.getMessage().contains("file is encrypted or is not a database:")) {
-                logger.logError("Android ciphered database will be deleted to self heal: " + e.getMessage(), "SQLite");
+                logger.logError("Android ciphered database will be deleted to self heal: " + e.getMessage(), "SQLite", e);
                 deleteDatabaseNow(dbname);
                 return openDatabase(dbname, key, cbc, false);
             } else {
@@ -389,7 +389,6 @@ public class SQLitePlugin extends CordovaPlugin {
             try {
                 this.mydb = openDatabase(dbname, this.dbkey, this.openCbc, false);
             } catch (Exception e) {
-                logger.logError("Error found when opening ciphered database: " + e.getMessage(), "SQLite");
                 Log.e(SQLitePlugin.class.getSimpleName(), "unexpected error, stopping db thread", e);
                 dbrmap.remove(dbname);
                 return;
@@ -406,7 +405,6 @@ public class SQLitePlugin extends CordovaPlugin {
                     dbq = q.take();
                 }
             } catch (Exception e) {
-                logger.logError("Error executing SQL query in ciphered database: " + e.getMessage(), "SQLite");
                 Log.e(SQLitePlugin.class.getSimpleName(), "unexpected error", e);
             }
 
@@ -427,13 +425,11 @@ public class SQLitePlugin extends CordovaPlugin {
                                 dbq.cbc.error("couldn't delete database");
                             }
                         } catch (Exception e) {
-                            logger.logError("Error while deleting ciphered database: " + e.getMessage(), "SQLite");
                             Log.e(SQLitePlugin.class.getSimpleName(), "couldn't delete database", e);
                             dbq.cbc.error("couldn't delete database: " + e);
                         }
                     }
                 } catch (Exception e) {
-                    logger.logError("Error while closing ciphered database: " + e.getMessage(), "SQLite");
                     Log.e(SQLitePlugin.class.getSimpleName(), "couldn't close database", e);
                     if (dbq.cbc != null) {
                         dbq.cbc.error("couldn't close database: " + e);

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -266,7 +266,7 @@ public class SQLitePlugin extends CordovaPlugin {
             // NOTE: NO Android locking/closing BUG workaround needed here
 
             if(selfHealingEnabled && e.getMessage().contains("file is encrypted or is not a database:")) {
-                logger.logError("Android database will be deleted to self heal: " + e.getMessage(), "SQLite");
+                logger.logError("Android ciphered database will be deleted to self heal: " + e.getMessage(), "SQLite");
                 deleteDatabaseNow(dbname);
                 return openDatabase(dbname, key, cbc, false);
             } else {
@@ -389,7 +389,7 @@ public class SQLitePlugin extends CordovaPlugin {
             try {
                 this.mydb = openDatabase(dbname, this.dbkey, this.openCbc, false);
             } catch (Exception e) {
-                logger.logError("Error opening database: " + e.getMessage(), "SQLite");
+                logger.logError("Error found when opening ciphered database: " + e.getMessage(), "SQLite");
                 Log.e(SQLitePlugin.class.getSimpleName(), "unexpected error, stopping db thread", e);
                 dbrmap.remove(dbname);
                 return;
@@ -406,7 +406,7 @@ public class SQLitePlugin extends CordovaPlugin {
                     dbq = q.take();
                 }
             } catch (Exception e) {
-                logger.logError("Error executeSqlBatch: " + e.getMessage(), "SQLite");
+                logger.logError("Error executing SQL query in ciphered database: " + e.getMessage(), "SQLite");
                 Log.e(SQLitePlugin.class.getSimpleName(), "unexpected error", e);
             }
 
@@ -427,13 +427,13 @@ public class SQLitePlugin extends CordovaPlugin {
                                 dbq.cbc.error("couldn't delete database");
                             }
                         } catch (Exception e) {
-                            logger.logError("Error deleteDatabaseNow: " + e.getMessage(), "SQLite");
+                            logger.logError("Error while deleting ciphered database: " + e.getMessage(), "SQLite");
                             Log.e(SQLitePlugin.class.getSimpleName(), "couldn't delete database", e);
                             dbq.cbc.error("couldn't delete database: " + e);
                         }
-                    }                    
+                    }
                 } catch (Exception e) {
-                    logger.logError("Error closeDatabaseNow: " + e.getMessage(), "SQLite");
+                    logger.logError("Error while closing ciphered database: " + e.getMessage(), "SQLite");
                     Log.e(SQLitePlugin.class.getSimpleName(), "couldn't close database", e);
                     if (dbq.cbc != null) {
                         dbq.cbc.error("couldn't close database: " + e);

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -266,7 +266,7 @@ public class SQLitePlugin extends CordovaPlugin {
             // NOTE: NO Android locking/closing BUG workaround needed here
 
             if(selfHealingEnabled && e.getMessage().contains("file is encrypted or is not a database:")) {
-                logger.logError("Android ciphered database will be deleted to self heal: " + e.getMessage(), "SQLite", e);
+                logger.logWarning("Android ciphered database will be deleted to self heal: " + e.getMessage(), "SQLite");
                 deleteDatabaseNow(dbname);
                 return openDatabase(dbname, key, cbc, false);
             } else {

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -80,7 +80,7 @@ sqlite_regexp(sqlite3_context * context, int argc, sqlite3_value ** values) {
 
         _logger = [OSLogger sharedInstance];
         
-        id selfHealingEnabledValue = [self.commandDelegate.settings objectForKey: [@"selfHealing" lowercaseString]];
+        id selfHealingEnabledValue = [self.commandDelegate.settings objectForKey: [@"EnableSQLCipherSelfHealing" lowercaseString]];
         if (selfHealingEnabledValue != nil) {
             selfHealingEnabled = [selfHealingEnabledValue boolValue];
         }

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -211,7 +211,7 @@ sqlite_regexp(sqlite3_context * context, int argc, sqlite3_value ** values) {
                     
                     if(selfHealingEnabled) {
                         [[command.arguments objectAtIndex:0] setObject:dbfilename forKey:@"path"];
-                        [_logger logError:[NSString stringWithFormat:@"iOS database will be deleted to self heal"] withModule:@"SQLite"];
+                        [_logger logError:[NSString stringWithFormat:@"iOS ciphered database will be deleted to self heal"] withModule:@"SQLite"];
                         [self deleteNow:command];
                         return [self openNow:command];
                     }

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -211,7 +211,7 @@ sqlite_regexp(sqlite3_context * context, int argc, sqlite3_value ** values) {
                     
                     if(selfHealingEnabled) {
                         [[command.arguments objectAtIndex:0] setObject:dbfilename forKey:@"path"];
-                        [_logger logError:[NSString stringWithFormat:@"iOS ciphered database will be deleted to self heal"] withModule:@"SQLite"];
+                        [_logger logWarning:[NSString stringWithFormat:@"iOS ciphered database will be deleted to self heal"] withModule:@"SQLite"];
                         [self deleteNow:command];
                         return [self openNow:command];
                     }


### PR DESCRIPTION
The self-healing mechanism is a mechanism that helps to recover mobile apps that are unable to open the ciphered local database. One known scenario when this can happen is when the mobile app's endpoint changes between versions.

 The self-heal mechanism consists in deleting the previous encrypted local database and to create a new one. So, instead of clients having errors in their apps, they will only lose the local configurations of the apps and no error screen will be shown. 