### PR TITLE
RNMT-4308 Allow promises support in OutSystems runtime

### DIFF
--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -85,7 +85,8 @@
   };
 
   SQLitePlugin.prototype.databaseFeatures = {
-    isSQLitePluginDatabase: true
+    isSQLitePluginDatabase: true,
+    hasPromiseSupport: true
   };
 
   SQLitePlugin.prototype.openDBs = {};

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -415,15 +415,17 @@
             txFailure = newSQLError(err);
           }
         }
-        if (--waiting === 0) {
-          if (txFailure) {
-            tx.abort(txFailure);
-          } else if (tx.executes.length > 0) {
-            tx.run();
-          } else {
-            tx.finish();
+        setTimeout(function() {
+          if (--waiting === 0) {
+            if (txFailure) {
+              tx.abort(txFailure);
+            } else if (tx.executes.length > 0) {
+              tx.run();
+            } else {
+              tx.finish();
+            }
           }
-        }
+        }, 0);
       };
     };
     i = 0;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR introduces an asynchronism point that will allow the usage of promises in OutSystems runtime.
In addition, a flag was created for runtime to know if the plugin version supports promises.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes https://outsystemsrd.atlassian.net/browse/RNMT-4308

<!--- Why is this change required? What problem does it solve? -->
Allow promises support in OutSystems runtime.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [ ] iOS platform
- [x] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
Tested the solution generating an app with the Ciphered Local Storage plugin and adding an aggregate (to access the database) in an environment prepared to accommodate this feature. Without the changes, the app shows a popup with an error message `undefined is not an object (evaluating 'e.list')`. With the changes applied to the sqlcipher-adapter, there is no error message.

<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly