### PR TITLE
RMET-1191 Cipher Plugin - Improve database self-healing policy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## cordova-sqlcipher-adapter 0.1.7-OS6
+
+- Fix: Add another use case for self-healing the database (https://outsystemsrd.atlassian.net/browse/RMET-1191)
+
+## cordova-sqlcipher-adapter 0.1.7-OS6
+
+- Logger removal for MABS 7
+
+
 ## cordova-sqlcipher-adapter 0.1.7-OS5
 
 - Support to 64-bits

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## cordova-sqlcipher-adapter 0.1.7-OS6
+## cordova-sqlcipher-adapter 0.1.7-OS7
 
 - Fix: Add another use case for self-healing the database (https://outsystemsrd.atlassian.net/browse/RMET-1191)
 

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -14,6 +14,8 @@ import android.util.Log;
 import com.outsystems.plugins.oslogger.OSLogger;
 import com.outsystems.plugins.oslogger.interfaces.Logger;
 
+import net.sqlcipher.database.SQLiteException;
+
 import java.io.File;
 import java.lang.IllegalArgumentException;
 import java.lang.Number;
@@ -264,8 +266,9 @@ public class SQLitePlugin extends CordovaPlugin {
             return mydb;
         } catch (Exception e) {
             // NOTE: NO Android locking/closing BUG workaround needed here
-
-            if(selfHealingEnabled && e.getMessage().contains("file is encrypted or is not a database:")) {
+            if(selfHealingEnabled && (e.getMessage().contains("file is encrypted or is not a database:") ||
+                    ((e instanceof SQLiteException) && e.getMessage().contains("file is not a database:") )))
+            {
                 logger.logWarning("Android ciphered database will be deleted to self heal: " + e.getMessage(), "SQLite");
                 deleteDatabaseNow(dbname);
                 return openDatabase(dbname, key, cbc, false);


### PR DESCRIPTION
## Description

- This PR adds another use case in which we want to self-heal the database. In case we get the error we added, then we want the database to self-heal.

## Context
<!--- Why is this change required? What problem does it solve? -->
https://outsystemsrd.atlassian.net/browse/RMET-1191


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
Tested locally in Android Studio. MABS 7 and 8 working.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly