### PR TITLE
fix(android, iOS): remove dependencies to OSLogger

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 - Update SQLite to 3.46.1 (https://outsystemsrd.atlassian.net/browse/RMET-3850).
 
+## cordova-sqlcipher-adapter 0.1.7-OS10
+
+- Fix: Remove dependencies to OSLogger (https://outsystemsrd.atlassian.net/browse/RMET-4297).
+
 ## cordova-sqlcipher-adapter 0.1.7-OS9
 
 - Update SQLCipher to 4.6.1, with support for 16KB page size devices (https://outsystemsrd.atlassian.net/browse/RMET-3602)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-sqlcipher-adapter",
-  "version": "0.1.7-OS9",
+  "version": "0.1.7-OS10",
   "description": "SQLCipher database adapter for PhoneGap/Cordova, based on cordova-sqlite-storage",
   "cordova": {
     "id": "cordova-sqlcipher-adapter",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-sqlcipher-adapter"
-    version="0.1.7-OS9">
+    version="0.1.7-OS10">
 
     <name>Cordova sqlcipher adapter</name>
 

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -9,8 +9,8 @@ package io.sqlc;
 import android.database.sqlite.SQLiteException;
 import android.util.Log;
 
-import com.outsystems.plugins.oslogger.OSLogger;
-import com.outsystems.plugins.oslogger.interfaces.Logger;
+//import com.outsystems.plugins.oslogger.OSLogger;
+//import com.outsystems.plugins.oslogger.interfaces.Logger;
 
 import java.io.File;
 
@@ -56,7 +56,7 @@ public class SQLitePlugin extends CordovaPlugin {
      */
     static Map<String, DBRunner> dbrmap = new ConcurrentHashMap<String, DBRunner>();
 
-    private Logger logger;
+    //private Logger logger;
     private boolean selfHealingEnabled = false;
     private boolean didTryCipherMigration = false;
 
@@ -74,7 +74,7 @@ public class SQLitePlugin extends CordovaPlugin {
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
-        logger = OSLogger.getInstance();
+        //logger = OSLogger.getInstance();
         selfHealingEnabled = preferences.getBoolean("EnableSQLCipherSelfHealing", false);
         SQLiteAndroidDatabase.initialize();
     }
@@ -252,10 +252,10 @@ public class SQLitePlugin extends CordovaPlugin {
             return mydb;
         } catch (Exception e) {
 
-            logger.logWarning("Got " + e.getMessage() + " exception.", "SQLite");
+            //logger.logWarning("Got " + e.getMessage() + " exception.", "SQLite");
 
             if(mydb != null && !didTryCipherMigration) {
-                logger.logVerbose("Will try Cipher Migration.", "SQLite");
+                //logger.logVerbose("Will try Cipher Migration.", "SQLite");
                 /*
                  * An error was found and will try to migrate.
                  * The migration process is described here: https://www.zetetic.net/sqlcipher/sqlcipher-api/#cipher_migrate
@@ -270,7 +270,7 @@ public class SQLitePlugin extends CordovaPlugin {
             if(selfHealingEnabled && (e.getMessage().contains("file is encrypted or is not a database:") ||
                     ((e instanceof SQLiteException) && e.getMessage().contains("file is not a database:") )))
             {
-                logger.logWarning("Android ciphered database will be deleted to self heal: " + e.getMessage(), "SQLite");
+                //logger.logWarning("Android ciphered database will be deleted to self heal: " + e.getMessage(), "SQLite");
                 deleteDatabaseNow(dbname);
                 return openDatabase(dbname, key, cbc, false);
             } else {

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -9,9 +9,6 @@ package io.sqlc;
 import android.database.sqlite.SQLiteException;
 import android.util.Log;
 
-//import com.outsystems.plugins.oslogger.OSLogger;
-//import com.outsystems.plugins.oslogger.interfaces.Logger;
-
 import java.io.File;
 
 import java.lang.IllegalArgumentException;
@@ -56,7 +53,6 @@ public class SQLitePlugin extends CordovaPlugin {
      */
     static Map<String, DBRunner> dbrmap = new ConcurrentHashMap<String, DBRunner>();
 
-    //private Logger logger;
     private boolean selfHealingEnabled = false;
     private boolean didTryCipherMigration = false;
 
@@ -74,7 +70,6 @@ public class SQLitePlugin extends CordovaPlugin {
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
-        //logger = OSLogger.getInstance();
         selfHealingEnabled = preferences.getBoolean("EnableSQLCipherSelfHealing", false);
         SQLiteAndroidDatabase.initialize();
     }
@@ -252,10 +247,10 @@ public class SQLitePlugin extends CordovaPlugin {
             return mydb;
         } catch (Exception e) {
 
-            //logger.logWarning("Got " + e.getMessage() + " exception.", "SQLite");
+            Log.w("SQLite", "Got " + e.getMessage() + " exception.");
 
             if(mydb != null && !didTryCipherMigration) {
-                //logger.logVerbose("Will try Cipher Migration.", "SQLite");
+                Log.v("SQLite", "Will try Cipher Migration.");
                 /*
                  * An error was found and will try to migrate.
                  * The migration process is described here: https://www.zetetic.net/sqlcipher/sqlcipher-api/#cipher_migrate
@@ -270,7 +265,7 @@ public class SQLitePlugin extends CordovaPlugin {
             if(selfHealingEnabled && (e.getMessage().contains("file is encrypted or is not a database:") ||
                     ((e instanceof SQLiteException) && e.getMessage().contains("file is not a database:") )))
             {
-                //logger.logWarning("Android ciphered database will be deleted to self heal: " + e.getMessage(), "SQLite");
+                Log.w("SQLite", "Android ciphered database will be deleted to self heal: " + e.getMessage());
                 deleteDatabaseNow(dbname);
                 return openDatabase(dbname, key, cbc, false);
             } else {

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -7,7 +7,7 @@
  */
 
 #import "SQLitePlugin.h"
-#import "OSLogger.h"
+//#import "OSLogger.h"
 #import "sqlite3.h"
 
 // Defines Macro to only log lines when in DEBUG mode
@@ -29,7 +29,7 @@
 @end
 
 @interface SQLitePlugin()
-@property (nonatomic, readonly, strong) id <OSLoggerProtocol> logger;
+//@property (nonatomic, readonly, strong) id <OSLoggerProtocol> logger;
 @property (nonatomic, assign, readonly) BOOL selfHealingEnabled;
 @end
 
@@ -48,7 +48,7 @@
         openDBs = [CustomPSPDFThreadSafeMutableDictionary dictionaryWithCapacity:0];
         appDBPaths = [NSMutableDictionary dictionaryWithCapacity:0];
 
-        _logger = [OSLogger sharedInstance];
+        //_logger = [OSLogger sharedInstance];
         
         id selfHealingEnabledValue = [self.commandDelegate.settings objectForKey: [@"EnableSQLCipherSelfHealing" lowercaseString]];
         if (selfHealingEnabledValue != nil) {
@@ -241,7 +241,7 @@
                     
                     if(selfHealingEnabled) {
                         [[command.arguments objectAtIndex:0] setObject:dbfilename forKey:@"path"];
-                        [_logger logWarning:[NSString stringWithFormat:@"iOS ciphered database will be deleted to self heal"] withModule:@"SQLite"];
+                       // [_logger logWarning:[NSString stringWithFormat:@"iOS ciphered database will be deleted to self heal"] withModule:@"SQLite"];
                         [self deleteNow:command];
                         return [self openNow:command migrateSqlCipher:false];
                     }

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -7,7 +7,6 @@
  */
 
 #import "SQLitePlugin.h"
-//#import "OSLogger.h"
 #import "sqlite3.h"
 
 // Defines Macro to only log lines when in DEBUG mode
@@ -29,7 +28,6 @@
 @end
 
 @interface SQLitePlugin()
-//@property (nonatomic, readonly, strong) id <OSLoggerProtocol> logger;
 @property (nonatomic, assign, readonly) BOOL selfHealingEnabled;
 @end
 
@@ -47,8 +45,6 @@
     {
         openDBs = [CustomPSPDFThreadSafeMutableDictionary dictionaryWithCapacity:0];
         appDBPaths = [NSMutableDictionary dictionaryWithCapacity:0];
-
-        //_logger = [OSLogger sharedInstance];
         
         id selfHealingEnabledValue = [self.commandDelegate.settings objectForKey: [@"EnableSQLCipherSelfHealing" lowercaseString]];
         if (selfHealingEnabledValue != nil) {
@@ -241,7 +237,8 @@
                     
                     if(selfHealingEnabled) {
                         [[command.arguments objectAtIndex:0] setObject:dbfilename forKey:@"path"];
-                       // [_logger logWarning:[NSString stringWithFormat:@"iOS ciphered database will be deleted to self heal"] withModule:@"SQLite"];
+                        NSLog(@"SQLite: iOS ciphered database will be deleted to self heal");
+                        
                         [self deleteNow:command];
                         return [self openNow:command migrateSqlCipher:false];
                     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Temporarily replaces calls to `OSLogger` with the platforms' default logs (`Log` for Android and `NSLog` for iOS), so that the plugin can be used in MABS 12 (Capacitor apps).

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4297

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Check latest Android and iOS MABS 12 builds in our development tenant.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly