### PR TITLE
feat: Support for SPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ spec/myplugin
 spec/plugins
 spec/platforms
 yarn.lock
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,57 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "cordova-sqlcipher-adapter",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "cordova-sqlcipher-adapter",
+            targets: ["SqlcipherAdapterPlugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master")
+    ],
+    targets: [
+        .target(
+            name: "SqlcipherAdapterPlugin",
+            dependencies: [
+                .product(name: "Cordova", package: "cordova-ios")
+            ],
+            path: "src",
+            sources: [
+                "ios/SQLitePlugin.m",
+                "ios/CustomPSPDFThreadSafeMutableDictionary.m",
+                "common/sqlite3.c"
+            ],
+            publicHeadersPath: "ios",
+            cSettings: [
+                .headerSearchPath("common"),
+                .define("SQLITE_HAS_CODEC"),
+                .define("HAVE_USLEEP", to: "1"),
+                .define("SQLITE_TEMP_STORE", to: "3"),
+                .define("SQLITE_EXTRA_INIT", to: "sqlcipher_extra_init"),
+                .define("SQLITE_EXTRA_SHUTDOWN", to: "sqlcipher_extra_shutdown"),
+                .define("SQLCIPHER_CRYPTO_CC"),
+                .define("SQLITE_LOCKING_STYLE", to: "1"),
+                .define("NDEBUG"),
+                .define("SQLITE_THREADSAFE", to: "1"),
+                .define("SQLITE_DEFAULT_SYNCHRONOUS", to: "3"),
+                .define("SQLITE_DEFAULT_MEMSTATUS", to: "0"),
+                .define("SQLITE_OMIT_DECLTYPE"),
+                .define("SQLITE_OMIT_DEPRECATED"),
+                .define("SQLITE_OMIT_PROGRESS_CALLBACK"),
+                .define("SQLITE_OMIT_SHARED_CACHE"),
+                .define("SQLITE_OMIT_LOAD_EXTENSION"),
+                .define("SQLITE_ENABLE_FTS3"),
+                .define("SQLITE_ENABLE_FTS3_PARENTHESIS"),
+                .define("SQLITE_ENABLE_FTS4"),
+                .define("SQLITE_ENABLE_RTREE"),
+                .define("SQLITE_ENABLE_FTS5"),
+                .define("SQLITE_ENABLE_JSON1")
+            ],
+            linkerSettings: [
+                .linkedFramework("Security")
+            ])
+    ]
+)

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,14 +52,14 @@
             </feature>
         </config-file>
 
-        <header-file src="src/ios/SQLitePlugin.h" nospm="true" />
-        <source-file src="src/ios/SQLitePlugin.m" compiler-flags="-DSQLITE_HAS_CODEC" nospm="true" />
+        <header-file src="src/ios/SQLitePlugin.h" />
+        <source-file src="src/ios/SQLitePlugin.m" compiler-flags="-DSQLITE_HAS_CODEC" />
 
         <source-file src="src/ios/CustomPSPDFThreadSafeMutableDictionary.m"
-                compiler-flags="-w" nospm="true" />
+                compiler-flags="-w" />
 
         <!-- SQLCipher source distribution and Security.framework dependency for iOS: -->
-        <header-file src="src/common/sqlite3.h" nospm="true" />
+        <header-file src="src/common/sqlite3.h" />
         <source-file src="src/common/sqlite3.c"
                      compiler-flags="-w
                                      -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1
@@ -74,9 +74,9 @@
                                      -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_LOAD_EXTENSION
                                      -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_RTREE
                                      -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_JSON1
-                                    " nospm="true" />
+                                    " />
 
-        <framework src="Security.framework" nospm="true" />
+        <framework src="Security.framework" />
     </platform>
 
     <!-- macOS (osx) -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,21 +45,21 @@
     </platform>
 
     <!-- iOS -->
-    <platform name="ios">
+    <platform name="ios" package="swift">
         <config-file target="config.xml" parent="/*">
             <feature name="SQLitePlugin">
                 <param name="ios-package" value="SQLitePlugin" />
             </feature>
         </config-file>
 
-        <header-file src="src/ios/SQLitePlugin.h" />
-        <source-file src="src/ios/SQLitePlugin.m" compiler-flags="-DSQLITE_HAS_CODEC" />
+        <header-file src="src/ios/SQLitePlugin.h" nospm="true" />
+        <source-file src="src/ios/SQLitePlugin.m" compiler-flags="-DSQLITE_HAS_CODEC" nospm="true" />
 
         <source-file src="src/ios/CustomPSPDFThreadSafeMutableDictionary.m"
-                compiler-flags="-w" />
+                compiler-flags="-w" nospm="true" />
 
         <!-- SQLCipher source distribution and Security.framework dependency for iOS: -->
-        <header-file src="src/common/sqlite3.h" />
+        <header-file src="src/common/sqlite3.h" nospm="true" />
         <source-file src="src/common/sqlite3.c"
                      compiler-flags="-w
                                      -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1
@@ -74,9 +74,9 @@
                                      -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_LOAD_EXTENSION
                                      -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_RTREE
                                      -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_JSON1
-                                    " />
+                                    " nospm="true" />
 
-        <framework src="Security.framework" />
+        <framework src="Security.framework" nospm="true" />
     </platform>
 
     <!-- macOS (osx) -->


### PR DESCRIPTION
**This PR adds support for SPM by:**

- Adding a `Package.swift` file with the required dependencies for SPM support.
- Updating `plugin.xml` to add `package="swift"` on the iOS platform and `nospm="true"` on all iOS source files, so the SPM build path uses `Package.swift` exclusively

**Tests**

✅ Cordova iOS CocoaPods — no regression [ciphered-cdv ipa](https://github.com/user-attachments/files/27016869/ciphered-cdv.ipa.zip)
✅ Capacitor iOS CocoaPods — no regression [ciphered-cap ipa](https://github.com/user-attachments/files/27016906/ciphered-cap.ipa.zip)
❌ Capacitor iOS SPM — not yet tested, blocked by missing implementation in Capacitor CLI — [RMET-5117](https://outsystemsrd.atlassian.net/browse/RMET-5117)

However, you can use this sample app to test [zip attached](https://github.com/user-attachments/files/27018600/capacitor-ciphered-exampleapp.zip)

**Note:** do not run `npm install`, as the `package.json` points to local paths. The `node_modules` in the zip are already set up and ready to test, just open the app in Xcode and build.

**References**

https://outsystemsrd.atlassian.net/browse/RMET-5136


[RMET-5117]: https://outsystemsrd.atlassian.net/browse/RMET-5117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ